### PR TITLE
Task/tl 681 current app

### DIFF
--- a/frodo.gemspec
+++ b/frodo.gemspec
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
-require File.expand_path('../lib/frodo/version', __FILE__)
+require File.expand_path('lib/frodo/version', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name          = 'frodo'
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'httparty'
   spec.add_runtime_dependency 'pundit'
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'bson'
+  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/frodo/acl.rb
+++ b/lib/frodo/acl.rb
@@ -6,7 +6,7 @@ module Frodo
       new(token, resource)
     end
 
-    def acl # rubocop:disable Metrics/MethodLength
+    def acl
       gandalf_acl if good_token?
     rescue Errno::ECONNREFUSED => e
       raise Frodo::Errors::BadUrlError.new(e.message)

--- a/lib/frodo/frodo_helpers.rb
+++ b/lib/frodo/frodo_helpers.rb
@@ -7,17 +7,17 @@ module Frodo
     end
 
     def current_user
-      @frodo_user ||= Frodo::User
-                      .instance(acl)
-                      .frodo_user # NOTE: "User" can be a Client Application or a User
+      @current_user ||= Frodo::User
+                        .instance(acl)
+                        .frodo_user # NOTE: "User" can be a Client Application or a User
     end
 
     def current_application_name
       @current_application_name ||= begin
-        if frodo_user.type == 'users'
-          frodo_user.client_application.name
+        if current_user.type == 'users'
+          current_user.client_application.name
         else
-          frodo_user.name
+          current_user.name
         end
       end
     end

--- a/lib/frodo/frodo_helpers.rb
+++ b/lib/frodo/frodo_helpers.rb
@@ -12,8 +12,14 @@ module Frodo
                       .frodo_user # NOTE: "User" can be a Client Application or a User
     end
 
-    def current_application
-      @current_application ||= Frodo::User.instance(acl).client_application
+    def current_application_name
+      @current_application_name ||= begin
+        if frodo_user.type == 'users'
+          frodo_user.client_application.name
+        else
+          frodo_user.name
+        end
+      end
     end
 
     private

--- a/lib/frodo/pundit/frodo_policy.rb
+++ b/lib/frodo/pundit/frodo_policy.rb
@@ -13,7 +13,7 @@ module Frodo
 
       attr_reader :frodo_user, :record, :privileges
 
-      alias_method :user, :frodo_user
+      alias user frodo_user
 
       def clean_privilege(priv)
         priv.to_s.delete('-').upcase

--- a/lib/frodo/pundit/frodo_policy.rb
+++ b/lib/frodo/pundit/frodo_policy.rb
@@ -20,7 +20,13 @@ module Frodo
       end
 
       def client_application_name
-        @client_application_name ||= frodo_user.name
+        @client_application_name ||= begin
+          if frodo_user.type == 'users'
+            frodo_user.client_application.name
+          else
+            frodo_user.name
+          end
+        end
       end
 
       # rubocop:disable Naming/PredicateName

--- a/lib/frodo/version.rb
+++ b/lib/frodo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Frodo
-  VERSION = '0.1.7'
+  VERSION = '1.0.0'
 end

--- a/spec/pundit/frodo_policy_spec.rb
+++ b/spec/pundit/frodo_policy_spec.rb
@@ -23,6 +23,12 @@ describe FrodoPolicyTester do
 
   subject { described_class.new(frodo_user, resource) }
   let(:resource) { OpenStruct }
+  let(:base_client_application_attributes) do
+    {
+      'name' => 'TEST_POLICY_APP',
+      'redirect_uri' => 'https://www.test_policy_app.com'
+    }
+  end
 
   describe 'when frodo_user is a user' do
     let(:frodo_user) { user }
@@ -43,13 +49,14 @@ describe FrodoPolicyTester do
 
     context '#salido_pos?' do
       context 'when the client application is the POS' do
-        let(:client_app) { 'SALIDO_POS' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'SALIDO_POS') }
         it 'is true' do
           expect(subject.salido_pos?).to be true
         end
       end
+
       context 'when the client application is not the POS' do
-        let(:client_app) { 'I_AM_BATMAN' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'I_AM_BATMAN') }
         it 'is false' do
           expect(subject.salido_pos?).to be false
         end
@@ -58,13 +65,14 @@ describe FrodoPolicyTester do
 
     context '#salido_bridge?' do
       context 'when the client application is the BRIDGE' do
-        let(:client_app) { 'SALIDO_BRIDGE' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'SALIDO_BRIDGE') }
         it 'is true' do
           expect(subject.salido_bridge?).to be true
         end
       end
+
       context 'when the client application is not the BRIDGE' do
-        let(:client_app) { 'I_AM_BATMAN' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'I_AM_BATMAN') }
         it 'is false' do
           expect(subject.salido_bridge?).to be false
         end
@@ -158,13 +166,13 @@ describe FrodoPolicyTester do
 
     context '#salido_pos?' do
       context 'when the client application is the POS' do
-        let(:client_app) { 'SALIDO_POS' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'SALIDO_POS') }
         it 'is true' do
           expect(subject.salido_pos?).to be true
         end
       end
       context 'when the client application is not the POS' do
-        let(:client_app) { 'I_AM_BATMAN' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'I_AM_BATMAN') }
         it 'is false' do
           expect(subject.salido_pos?).to be false
         end
@@ -173,13 +181,13 @@ describe FrodoPolicyTester do
 
     context '#salido_bridge?' do
       context 'when the client application is the BRIDGE' do
-        let(:client_app) { 'SALIDO_BRIDGE' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'SALIDO_BRIDGE') }
         it 'is true' do
           expect(subject.salido_bridge?).to be true
         end
       end
       context 'when the client application is not the BRIDGE' do
-        let(:client_app) { 'I_AM_BATMAN' }
+        let(:client_application_attributes) { base_client_application_attributes.merge('name' => 'I_AM_BATMAN') }
         it 'is false' do
           expect(subject.salido_bridge?).to be false
         end

--- a/spec/support/frodo_user.rb
+++ b/spec/support/frodo_user.rb
@@ -10,9 +10,15 @@ RSpec.shared_context 'frodo_user' do
   end
 
   let(:resource_owner_id) { '1234567890uuid' }
-  let(:client_app) { 'TEST_POLICY_APP' }
+  let(:client_application_id) { '0987654321uuid' }
   let(:gandalf_privileges) { [] }
   let(:groups) { [] }
+  let(:client_application_attributes) do
+    {
+      'name' => 'TEST_POLICY_APP',
+      'redirect_uri' => 'https://www.test_policy_app.com'
+    }
+  end
   let(:user_attributes) do
     {
       'disabled_by_salido' => false,
@@ -33,14 +39,25 @@ RSpec.shared_context 'frodo_user' do
         'id' => 0,
         'type' => 'acls',
         'attributes' => {
-          'client_application' => client_app,
           'privileges' => gandalf_privileges
         },
         'relationships' => {
+          'client_application' => {
+            'data' => {
+              'id' => client_application_id,
+              'type' => 'clientapplications'
+            }
+          },
           'groups' => { 'data' => groups }
         }
       },
-      'included' => []
+      'included' => [
+        {
+          'id' => client_application_id,
+          'type' => 'client_applications',
+          'attributes' => client_application_attributes
+        }
+      ]
     }
   end
 
@@ -51,10 +68,15 @@ RSpec.shared_context 'frodo_user' do
         'id' => 0,
         'type' => 'acls',
         'attributes' => {
-          'client_application' => client_app,
           'privileges' => gandalf_privileges
         },
         'relationships' => {
+          'client_application' => {
+            'data' => {
+              'id' => client_application_id,
+              'type' => 'clientapplications'
+            }
+          },
           'user' => {
             'data' => {
               'id' => resource_owner_id,
@@ -65,6 +87,11 @@ RSpec.shared_context 'frodo_user' do
         }
       },
       'included' => [
+        {
+          'id' => client_application_id,
+          'type' => 'client_applications',
+          'attributes' => client_application_attributes
+        },
         {
           'id' => resource_owner_id,
           'type' => 'users',

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -13,7 +13,14 @@ RSpec.shared_context 'shared context' do
 
   let(:gandalf_user_id) { SecureRandom.uuid }
 
-  let(:client_application_name) { 'TESTAPP10' }
+  let(:groups) { [] }
+  let(:client_application_id) { '0987654321uuid' }
+  let(:client_application_attributes) do
+    {
+      'name' => 'TEST_POLICY_APP',
+      'redirect_uri' => 'https://www.test_policy_app.com'
+    }
+  end
 
   let(:client_application_acl) do
     JSON.unparse(
@@ -22,14 +29,25 @@ RSpec.shared_context 'shared context' do
         'id' => 0,
         'type' => 'acls',
         'attributes' => {
-          'client_application' => client_application_name,
           'privileges' => gandalf_privileges
         },
         'relationships' => {
-          'groups' => { 'data' => [] }
+          'client_application' => {
+            'data' => {
+              'id' => client_application_id,
+              'type' => 'clientapplications'
+            }
+          },
+          'groups' => { 'data' => groups }
         }
       },
-      'included' => []
+      'included' => [
+        {
+          'id' => client_application_id,
+          'type' => 'client_applications',
+          'attributes' => client_application_attributes
+        }
+      ]
     )
   end
 
@@ -40,10 +58,15 @@ RSpec.shared_context 'shared context' do
         'id' => 0,
         'type' =>  'acls',
         'attributes' => {
-          'client_application' =>  client_application_name,
           'privileges' => gandalf_privileges
         },
         'relationships' => {
+          'client_application' => {
+            'data' => {
+              'id' => client_application_id,
+              'type' => 'clientapplications'
+            }
+          },
           'user' => {
             'data' => {
               'id' =>  gandalf_user_id,
@@ -54,6 +77,11 @@ RSpec.shared_context 'shared context' do
         }
       },
       'included' => [
+        {
+          'id' => client_application_id,
+          'type' => 'client_applications',
+          'attributes' => client_application_attributes
+        },
         {
           'id' =>  gandalf_user_id,
           'type' => 'users',


### PR DESCRIPTION
https://salido.atlassian.net/browse/TL-681

I know the ticket refers to `current_application` and this PR changes it to `current_application_name`.  I think `current_application_name` is more appropriate because that's essentially what `current_application` was getting in the first place.  Just the name of the application.  Now that we're returning a bunch of application attributes, I think this is more clear.

Will bump the version once this is approved